### PR TITLE
Fix missing Iterable/Symbol with core-js. Remove es6-shim to fix conflict with core-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "zone.js": "^0.7.7"
   },
   "devDependencies": {
-    "@types/es6-shim": "^0.31.32",
+    "@types/core-js": "^0.9.36",
     "@types/jasmine": "^2.5.43",
     "@types/node": "^7.0.5",
     "angular2-load-children-loader": "^0.1.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "types": [
       "node",
       "jasmine",
-      "es6-shim"
+      "core-js"
     ]
   },
   "compileOnSave": false,


### PR DESCRIPTION
Fix missing Iterable/Symbol with core-js.
Remove es6-shim to fix conflict with core-js